### PR TITLE
Add component-id annotation and clean catalog-info.yaml for idp-presentation

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,8 +3,10 @@ kind: Component
 metadata:
   name: idp-presentation
   annotations:
+    custom.backstage.io/component-id: "5012663f7937908f089f72d65157d3aac3c81a916947c6c3ec11c31848cac31e"
     github.com/project-slug: rtsarakaki/idp-presentation
 spec:
-  type: other
-  lifecycle: unknown
+  system: portfolio
+  type: website
+  lifecycle: production
   owner: developers


### PR DESCRIPTION
This PR:

1. Adds the `custom.backstage.io/component-id: "5012663f7937908f089f72d65157d3aac3c81a916947c6c3ec11c31848cac31e"` annotation to link this component with the database record
2. Synchronizes catalog-info.yaml with the database:
   
   - Updates spec.type to match database
   - Updates spec.lifecycle to match database
   - Updates spec.owner to match database
   - Updates spec.system to match database

This ensures the catalog-info.yaml stays synchronized with the database. The database is the source of truth, and this PR updates the file to match.

This was automatically generated when the component was edited via the Components Management interface.